### PR TITLE
Added StrQueue child class to enforce string only queues

### DIFF
--- a/queue.h
+++ b/queue.h
@@ -1,6 +1,7 @@
 // Andrew Stam, Hak Joon Lee - CS 4500 Assignment 1
 #pragma once
 #include "object.h"
+#include "string.h"
 
 // Represents a queue of objects (where String inherits from Object)
 class Queue {
@@ -12,24 +13,39 @@ class Queue {
 		~Queue();
 
 		// Insert the given Object at the end of the Queue
-		void enqueue(Object* o);
-
+		void enqueue(Object* o);	
+	
 		// Remove and return the Object at the front of the Queue
 		Object* dequeue();
 
 		// Clear the elements of the Queue
-		void clear();
+		virtual void clear();
 
 		// Check if the Queue is empty
-		bool isEmpty();
+		virtual bool isEmpty();
 
 		// Return the Object at the front of the Queue without removing the element
 		Object* peek();
 
 		// Return the size of the Queue
-		size_t size();
+		virtual size_t size();
 
 		// Return the Object at the given index without removing the element
 		Object* get(size_t index);
-}
+};
 
+class StrQueue : public Queue {
+	public:
+		// Insert the given String at the end of the Queue
+		void enqueue(String* o);	
+	
+		// Remove and return the String at the front of the Queue
+		String* dequeue();
+
+		// Return the String at the front of the Queue without removing the element
+		String* peek();
+
+		// Return the String at the given index without removing the element
+		String* get(size_t index);	
+
+};

--- a/string.h
+++ b/string.h
@@ -1,0 +1,50 @@
+#pragma once                                                                     
+//lang::CwC                                                                      
+#include "object.h"                                                              
+#include <cassert>     
+#include <stdlib.h>
+
+/**                                                                              
+ * An immutable string class. Values passed in are copied and deleted            
+ * upon destruction.                                                             
+ * author: vitekj@me.com                                                         
+ */                                                                              
+class String : public Object {                                                   
+ public:                                                                       
+  /** Construct a string copying s */                                            
+  String(char* s);                                                         
+                                                                                 
+  /** Construct a string copying s */                                            
+  String(const char* s);                                                     
+                                                                                 
+  /** This constructor takes ownership of the char* s. The char*                 
+   *  will be delete with the string. Use with caution. The first                
+   *  argument is there to differentiate this constructor from the               
+   *  standard one. */                                                           
+  String(bool steal, char* s);                                                               
+                                                                                 
+  /** Delete the string and free its data */                                     
+  ~String ();
+
+  /** Compare strings for equality. */                                           
+  bool equals(Object* other);                                                   
+                                                                                          
+  /** Returns 0 if strings are equal, >0 if this string is larger,               
+   *  <0 otherwise */                                                            
+  int compare(String* tgt);
+
+  /** Textbook hash function on strings.   */                                    
+  size_t hash_me_();                                                           
+                                                                                 
+  /** Number of non \0 characters in this string */                              
+  size_t size();                                              
+                                                                                 
+  /** Concatenate the strings, return a new object */                            
+  String* concat(String* other);
+
+   /** Return a newly allocated char* with this string value */                   
+  char* to_string();                                 
+                                                                                 
+  /** Print this string on stdout. */                                            
+  void print();                       
+};    


### PR DESCRIPTION
After looking at the spec for assignment 2, we need to have a queue that strictly deals with strings. We've added a subclass that only allows functions that will push strings into the queue to ensure all the objects in the queue are strings.

From the spec:

> The Queue class should support normal push and pop operations, the values that need to be supported are Strings and Objects.

We also added a string.h file from Jan's Piazza post answer: 
[https://piazza.com/class/k51bluky59n2jr?cid=166](https://piazza.com/class/k51bluky59n2jr?cid=166)