### PR TITLE
Changed NULL to nullptr

### DIFF
--- a/queue.h
+++ b/queue.h
@@ -17,7 +17,7 @@ class Queue {
 		void enqueue(Object* o);	
 	
 		// Remove and return the Object at the front of the Queue
-		// If the queue is empty, return NULL
+		// If the queue is empty, return nullptr
 		Object* dequeue();
 
 		// Clear the elements of the Queue
@@ -27,14 +27,14 @@ class Queue {
 		virtual bool isEmpty();
 
 		// Return the Object at the front of the Queue without removing the element
-		// If the queue is empty, return NULL
+		// If the queue is empty, return nullptr
 		Object* peek();
 
 		// Return the size of the Queue
 		virtual size_t size();
 
 		// Return the Object at the given index without removing the element
-		// If out of bounds, return NULL
+		// If out of bounds, return nullptr
 		Object* get(size_t index);
 };
 
@@ -51,14 +51,14 @@ class StrQueue : public Queue {
 		void enqueue(String* o);	
 	
 		// Remove and return the String at the front of the Queue
-		// If the queue is empty, return NULL
+		// If the queue is empty, return nullptr
 		String* dequeue();
 
 		// Return the String at the front of the Queue without removing the element
-		// If the queue is empty, return NULL
+		// If the queue is empty, return nullptr
 		String* peek();
 
 		// Return the String at the given index without removing the element
-		// If out of bounds, return NULL
+		// If out of bounds, return nullptr
 		String* get(size_t index);	
 };


### PR DESCRIPTION
It *would be nice* if we would have functions return nullptr instead of NULL when certain functions can't find elements.

nullptr is almost the same as NULL, except it has safer type checking, here's a blog post about it:
[https://embeddedartistry.com/blog/2017/03/08/migrating-from-c-to-c-null-vs-nullptr/](https://embeddedartistry.com/blog/2017/03/08/migrating-from-c-to-c-null-vs-nullptr/)

>nullptr is a new keyword introduced in C++11. nullptr is meant as a replacement to NULL. nullptr provides a typesafe pointer value representing an empty (null) pointer.

>The general rule of thumb that I recommend is that you should start using nullptr whenever you would have used NULL in the past.

If this isn't implemented, we more than likely would be totally fine.